### PR TITLE
Inherit the environment when spawning a new thread

### DIFF
--- a/src/Threading/Thread.php
+++ b/src/Threading/Thread.php
@@ -66,9 +66,19 @@ class Thread extends \Thread
          * be garbage data and unserializable values (like resources) will be
          * lost. This happens even with thread-safe objects.
          */
-        if ('' !== $this->autoloaderPath) {
-            require $this->autoloaderPath;
+        // If inheriting the autoloader failed, re-register it now.
+        if (empty(spl_autoload_functions())) {
+            foreach (get_declared_classes() as $className) {
+                if (strpos($className, 'ComposerAutoloaderInit') === 0) {
+                    $classLoader = $className::getLoader();
+                    break;
+                }
+            }
         }
+
+        // Erase the old event loop inherited from the parent thread and create
+        // a new one.
+        Loop\loop(Loop\create());
 
         // At this point, the thread environment has been prepared so begin using the thread.
         $channel = new Channel($this->socket);

--- a/src/Threading/Thread.php
+++ b/src/Threading/Thread.php
@@ -43,10 +43,10 @@ class Thread extends \Thread
     /**
      * Creates a new thread object.
      *
-     * @param resource $socket IPC communication socket.
-     * @param callable $function The function to execute in the thread.
-     * @param mixed[] $args Arguments to pass to the function.
-     * @param string $autoloaderPath Path to autoloader include file.
+     * @param resource $socket         IPC communication socket.
+     * @param callable $function       The function to execute in the thread.
+     * @param mixed[]  $args           Arguments to pass to the function.
+     * @param string   $autoloaderPath Path to autoloader include file.
      */
     public function __construct($socket, callable $function, array $args = [], $autoloaderPath = '')
     {
@@ -61,18 +61,17 @@ class Thread extends \Thread
      */
     public function run()
     {
-        /* First thing we need to do is initialize the class autoloader. If we
-         * don't do this first, objects we receive from other threads will just
-         * be garbage data and unserializable values (like resources) will be
-         * lost. This happens even with thread-safe objects.
+        /* First thing we need to do is re-initialize the class autoloader. If
+         * we don't do this first, any object of a class that was loaded after
+         * the thread started will just be garbage data and unserializable
+         * values (like resources) will be lost. This happens even with
+         * thread-safe objects.
          */
-        // If inheriting the autoloader failed, re-register it now.
-        if (empty(spl_autoload_functions())) {
-            foreach (get_declared_classes() as $className) {
-                if (strpos($className, 'ComposerAutoloaderInit') === 0) {
-                    $classLoader = $className::getLoader();
-                    break;
-                }
+        foreach (get_declared_classes() as $className) {
+            if (strpos($className, 'ComposerAutoloaderInit') === 0) {
+                // Calling getLoader() will register the class loader for us
+                $className::getLoader();
+                break;
             }
         }
 

--- a/src/Threading/Thread.php
+++ b/src/Threading/Thread.php
@@ -16,11 +16,6 @@ use Icicle\Loop;
 class Thread extends \Thread
 {
     /**
-     * @var string Path to an autoloader to include.
-     */
-    public $autoloaderPath;
-
-    /**
      * @var callable The function to execute in the thread.
      */
     private $function;
@@ -43,14 +38,12 @@ class Thread extends \Thread
     /**
      * Creates a new thread object.
      *
-     * @param resource $socket         IPC communication socket.
-     * @param callable $function       The function to execute in the thread.
-     * @param mixed[]  $args           Arguments to pass to the function.
-     * @param string   $autoloaderPath Path to autoloader include file.
+     * @param resource $socket   IPC communication socket.
+     * @param callable $function The function to execute in the thread.
+     * @param mixed[]  $args     Arguments to pass to the function.
      */
-    public function __construct($socket, callable $function, array $args = [], $autoloaderPath = '')
+    public function __construct($socket, callable $function, array $args = [])
     {
-        $this->autoloaderPath = $autoloaderPath;
         $this->function = $function;
         $this->args = $args;
         $this->socket = $socket;

--- a/src/Threading/ThreadContext.php
+++ b/src/Threading/ThreadContext.php
@@ -60,7 +60,7 @@ class ThreadContext implements ContextInterface
             throw new SynchronizationError('The thread has already been started.');
         }
 
-        $this->thread->start(PTHREADS_INHERIT_INI);
+        $this->thread->start(PTHREADS_INHERIT_ALL);
     }
 
     /**

--- a/src/Threading/ThreadContext.php
+++ b/src/Threading/ThreadContext.php
@@ -40,7 +40,7 @@ class ThreadContext implements ContextInterface
         list($channel, $socket) = Channel::createSocketPair();
 
         $this->channel = new Channel($channel);
-        $this->thread = new Thread($socket, $function, $args, $this->getComposerAutoloader());
+        $this->thread = new Thread($socket, $function, $args);
     }
 
     /**
@@ -145,29 +145,5 @@ class ThreadContext implements ContextInterface
         yield new Lock(function () {
             $this->thread->release();
         });
-    }
-
-    /**
-     * Gets the full path to the Composer autoloader.
-     *
-     * If no Composer autoloader is being used, `null` is returned.
-     *
-     * @return string
-     */
-    private function getComposerAutoloader()
-    {
-        static $path;
-
-        if (null !== $path) {
-            return $path;
-        }
-
-        foreach (get_included_files() as $path) {
-            if (preg_match('/vendor\/autoload.php$/i', $path)) {
-                return $path;
-            }
-        }
-
-        return $path = '';
     }
 }


### PR DESCRIPTION
When starting a new thread, `PTHREADS_INHERIT_ALL` is used to allow nested closures to be used inside a thread context. This also allows using classes, anonymous classes, and functions defined in the same file that spawns the thread.

The Composer autoloader used in the parent is duplicated and re-used in the child thread.

Performance hit has not been analyzed, though I imagine it would actually be better since needed classes don't have to be loaded from disk again.

This does require unreleased fixes to pthreads to work.
